### PR TITLE
c-siphash: Support SipHash variants other than SipHash24

### DIFF
--- a/src/c-siphash.c
+++ b/src/c-siphash.c
@@ -88,23 +88,8 @@ _c_public_ void c_siphash_init(CSipHash *state, const uint8_t seed[16]) {
         };
 }
 
-/**
- * c_siphash_append() - hash stream of data
- * @state:              context object
- * @bytes:              array of input bytes
- * @n_bytes:            number of input bytes
- *
- * This feeds an array of bytes into the SipHash state machine. This is a
- * streaming-capable API. That is, the resulting hash is the same, regardless
- * of the way you chunk the input.
- * This function simply feeds the given bytes into the SipHash state machine.
- * It does not produce a final hash. You can call this function many times to
- * append more data. To retrieve the final hash, call c_siphash_finalize().
- *
- * Note that this implementation works best when used with chunk-sizes of
- * multiples of 64bit (8-bytes). This is not a requirement, though.
- */
-_c_public_ void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n_bytes) {
+
+static inline _c_always_inline_ void c_siphash_append_N(CSipHash *state, const uint8_t *bytes, size_t n_bytes, unsigned N) {
         const uint8_t *end = bytes + n_bytes;
         size_t left = state->n_bytes & 7;
         uint64_t m;
@@ -123,8 +108,8 @@ _c_public_ void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n
                         return;
 
                 state->v3 ^= state->padding;
-                c_siphash_sipround(state);
-                c_siphash_sipround(state);
+                for (unsigned i = 0; i < N; i++)
+                        c_siphash_sipround(state);
                 state->v0 ^= state->padding;
 
                 state->padding = 0;
@@ -141,8 +126,8 @@ _c_public_ void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n
                 m = c_siphash_read_le64(bytes);
 
                 state->v3 ^= m;
-                c_siphash_sipround(state);
-                c_siphash_sipround(state);
+                for (unsigned i = 0; i < N; i++)
+                        c_siphash_sipround(state);
                 state->v0 ^= m;
         }
 
@@ -179,6 +164,48 @@ _c_public_ void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n
         }
 }
 
+static inline _c_always_inline_ uint64_t c_siphash_finalize_NM(CSipHash *state, unsigned N, unsigned M) {
+        uint64_t b;
+
+        b = state->padding | (((uint64_t) state->n_bytes) << 56);
+
+        state->v3 ^= b;
+        for (unsigned i = 0; i < N; i++)
+                c_siphash_sipround(state);
+        state->v0 ^= b;
+
+        state->v2 ^= 0xff;
+
+        for (unsigned i = 0; i < M; i++)
+                c_siphash_sipround(state);
+
+        return state->v0 ^ state->v1 ^ state->v2  ^ state->v3;
+}
+
+/**
+ * c_siphash_append() - hash stream of data
+ * @state:              context object
+ * @bytes:              array of input bytes
+ * @n_bytes:            number of input bytes
+ *
+ * This feeds an array of bytes into the SipHash state machine. This is a
+ * streaming-capable API. That is, the resulting hash is the same, regardless
+ * of the way you chunk the input.
+ * This function simply feeds the given bytes into the SipHash state machine.
+ * It does not produce a final hash. You can call this function many times to
+ * append more data. To retrieve the final hash, call c_siphash_finalize().
+ *
+ * Note that this implementation works best when used with chunk-sizes of
+ * multiples of 64bit (8-bytes). This is not a requirement, though.
+ */
+_c_public_ void c_siphash_append_24(CSipHash *state, const uint8_t *bytes, size_t n_bytes) {
+        c_siphash_append_N(state, bytes, n_bytes, 2);
+}
+
+_c_public_ void c_siphash_append_13(CSipHash *state, const uint8_t *bytes, size_t n_bytes) {
+        c_siphash_append_N(state, bytes, n_bytes, 1);
+}
+
 /**
  * c_siphash_finalize() - finalize hash
  * @state:              context object
@@ -194,24 +221,12 @@ _c_public_ void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n
  *
  * Return: 64bit hash value
  */
-_c_public_ uint64_t c_siphash_finalize(CSipHash *state) {
-        uint64_t b;
+_c_public_ uint64_t c_siphash_finalize_24(CSipHash *state) {
+        return c_siphash_finalize_NM(state, 2, 4);
+}
 
-        b = state->padding | (((uint64_t) state->n_bytes) << 56);
-
-        state->v3 ^= b;
-        c_siphash_sipround(state);
-        c_siphash_sipround(state);
-        state->v0 ^= b;
-
-        state->v2 ^= 0xff;
-
-        c_siphash_sipround(state);
-        c_siphash_sipround(state);
-        c_siphash_sipround(state);
-        c_siphash_sipround(state);
-
-        return state->v0 ^ state->v1 ^ state->v2  ^ state->v3;
+_c_public_ uint64_t c_siphash_finalize_13(CSipHash *state) {
+        return c_siphash_finalize_NM(state, 1, 3);
 }
 
 /**
@@ -235,11 +250,20 @@ _c_public_ uint64_t c_siphash_finalize(CSipHash *state) {
  *
  * Return: 64bit hash value
  */
-_c_public_ uint64_t c_siphash_hash(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes) {
+_c_public_ uint64_t c_siphash_hash_24(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes) {
         CSipHash state;
 
         c_siphash_init(&state, seed);
-        c_siphash_append(&state, bytes, n_bytes);
+        c_siphash_append_24(&state, bytes, n_bytes);
 
-        return c_siphash_finalize(&state);
+        return c_siphash_finalize_24(&state);
+}
+
+_c_public_ uint64_t c_siphash_hash_13(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes) {
+        CSipHash state;
+
+        c_siphash_init(&state, seed);
+        c_siphash_append_13(&state, bytes, n_bytes);
+
+        return c_siphash_finalize_13(&state);
 }

--- a/src/c-siphash.c
+++ b/src/c-siphash.c
@@ -8,7 +8,7 @@
  *
  * So far, only SipHash24 is implemented, since there was no need for other
  * parameters. However, adjusted c_siphash_append_X() and
- * C_siphash_finalize_Y() can be easily provided, if required.
+ * c_siphash_finalize_Y() can be easily provided, if required.
  */
 
 #include <c-stdaux.h>

--- a/src/c-siphash.h
+++ b/src/c-siphash.h
@@ -50,10 +50,18 @@ struct CSipHash {
 #define C_SIPHASH_NULL {0}
 
 void c_siphash_init(CSipHash *state, const uint8_t seed[16]);
-void c_siphash_append(CSipHash *state, const uint8_t *bytes, size_t n_bytes);
-uint64_t c_siphash_finalize(CSipHash *state);
 
-uint64_t c_siphash_hash(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes);
+void c_siphash_append_13(CSipHash *state, const uint8_t *bytes, size_t n_bytes);
+uint64_t c_siphash_finalize_13(CSipHash *state);
+uint64_t c_siphash_hash_13(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes);
+
+void c_siphash_append_24(CSipHash *state, const uint8_t *bytes, size_t n_bytes);
+uint64_t c_siphash_finalize_24(CSipHash *state);
+uint64_t c_siphash_hash_24(const uint8_t seed[16], const uint8_t *bytes, size_t n_bytes);
+
+#define c_siphash_append c_siphash_append_24
+#define c_siphash_finalize c_siphash_finalize_24
+#define c_siphash_hash c_siphash_hash_24
 
 #ifdef __cplusplus
 }

--- a/src/libcsiphash.def
+++ b/src/libcsiphash.def
@@ -1,6 +1,9 @@
-LIBRARY csiphash-1-0
+LIBRARY csiphash-2-0
 EXPORTS
         c_siphash_init
-        c_siphash_append
-        c_siphash_finalize
-        c_siphash_hash
+        c_siphash_append_13
+        c_siphash_append_24
+        c_siphash_finalize_13
+        c_siphash_finalize_24
+        c_siphash_hash_13
+        c_siphash_hash_24

--- a/src/libcsiphash.sym
+++ b/src/libcsiphash.sym
@@ -7,3 +7,13 @@ global:
 local:
        *;
 };
+
+LIBCSIPHASH_2 {
+global:
+        c_siphash_append_13;
+        c_siphash_append_24;
+        c_siphash_finalize_13;
+        c_siphash_finalize_24;
+        c_siphash_hash_13;
+        c_siphash_hash_24;
+} LIBCSIPHASH_1;

--- a/src/test-api.c
+++ b/src/test-api.c
@@ -17,11 +17,11 @@ static void test_api(void) {
         uint64_t hash1, hash2;
 
         c_siphash_init(&state, seed);
-        c_siphash_append(&state, NULL, 0);
-        hash1 = c_siphash_finalize(&state);
+        c_siphash_append_24(&state, NULL, 0);
+        hash1 = c_siphash_finalize_24(&state);
         assert(hash1 == 12552310112479190712ULL);
 
-        hash2 = c_siphash_hash(seed, NULL, 0);
+        hash2 = c_siphash_hash_24(seed, NULL, 0);
         assert(hash1 == hash2);
 }
 

--- a/src/test-basic.c
+++ b/src/test-basic.c
@@ -24,12 +24,12 @@ static void do_reference_test(const uint8_t *in, size_t len, const uint8_t *key)
         c_assert(state.v1 == 0x6b617f6d656e6665);
         c_assert(state.v2 == 0x6b7f62616d677361);
         c_assert(state.v3 == 0x7b6b696e727e6c7b);
-        c_siphash_append(&state, in, len);
+        c_siphash_append_24(&state, in, len);
         c_assert(state.v0 == 0x4a017198de0a59e0);
         c_assert(state.v1 == 0x0d52f6f62a4f59a4);
         c_assert(state.v2 == 0x634cb3577b01fd3d);
         c_assert(state.v3 == 0xa5224d6f55c7d9c8);
-        out = c_siphash_finalize(&state);
+        out = c_siphash_finalize_24(&state);
         c_assert(out == 0xa129ca6149be45e5);
         c_assert(state.v0 == 0xf6bcd53893fecff1);
         c_assert(state.v1 == 0x54b9964c7ea0d937);
@@ -41,16 +41,16 @@ static void do_reference_test(const uint8_t *in, size_t len, const uint8_t *key)
         for (i = 0; i < len; i++) {
                 for (j = i; j < len; j++) {
                         c_siphash_init(&state, key);
-                        c_siphash_append(&state, in, i);
-                        c_siphash_append(&state, &in[i], j - i);
-                        c_siphash_append(&state, &in[j], len - j);
-                        out = c_siphash_finalize(&state);
+                        c_siphash_append_24(&state, in, i);
+                        c_siphash_append_24(&state, &in[i], j - i);
+                        c_siphash_append_24(&state, &in[j], len - j);
+                        out = c_siphash_finalize_24(&state);
                         c_assert(out == 0xa129ca6149be45e5);
                 }
         }
 
         /* verify c_siphash_hash() produces the same result */
-        c_assert(out == c_siphash_hash(key, in, len));
+        c_assert(out == c_siphash_hash_24(key, in, len));
 }
 
 static void test_reference(void) {
@@ -87,10 +87,10 @@ static void test_short_hashes(void) {
 
         /* hashing 1, 2, 3, 4, 5, ..., 16 bytes, with the byte after the buffer different */
         for (i = 1; i <= sizeof one; i++) {
-                c_siphash_append(&state1, one, i);
+                c_siphash_append_24(&state1, one, i);
 
                 two[i-1] = one[i-1];
-                c_siphash_append(&state2, two, i);
+                c_siphash_append_24(&state2, two, i);
 
                 c_assert(memcmp(&state1, &state2, sizeof state1) == 0);
         }
@@ -100,12 +100,12 @@ static void test_short_hashes(void) {
                 memset(two, 0, sizeof(two));
 
                 for (j = 1; j <= sizeof one; j++) {
-                        c_siphash_append(&state1, one, i);
-                        c_siphash_append(&state1, one, j);
+                        c_siphash_append_24(&state1, one, i);
+                        c_siphash_append_24(&state1, one, j);
 
-                        c_siphash_append(&state2, one, i);
+                        c_siphash_append_24(&state2, one, i);
                         two[j-1] = one[j-1];
-                        c_siphash_append(&state2, two, j);
+                        c_siphash_append_24(&state2, two, j);
 
                         c_assert(memcmp(&state1, &state2, sizeof state1) == 0);
                 }


### PR DESCRIPTION
Rust and Python 3.11 use SipHash13 for their hashing needs, stating that this variant has similar security properties as SipHash24 but is slightly faster for long inputs. I believe this variant may thus become more popular.

I gave it a try at writing the minimum infrastructure required to support other SipHash variants. Initially I wrote a macro to generate `c_siphash_update_{N}()` and `c_siphash_finalize_{N}{M}()` but then it occurred to me that the compiler may be smart enough to embed the code and unroll the loops in a `static inline` function. The helper function looks nicer, thus I went for this solution, although I haven't check if effectively the compiler optimizes it away.

The proposed patch simply introduces the `static inline` helpers and redefines `c_siphash_update()` and `c_siphash_finalize()` in terms of it. @dvdhrm I would appreciate if you could confirm that this is something you would like to support and that this is the correct approach before going further.