### PR TITLE
fix generated pkgconfig

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,7 @@ if not meson.is_subproject()
                 description: project_description,
                 filebase: 'libcsiphash-'+major,
                 libraries: libcsiphash_both.get_shared_lib(),
+                libraries_private: libcsiphash_both.get_static_lib(),
                 name: 'libcsiphash',
                 version: meson.project_version(),
         )


### PR DESCRIPTION
1.dep libcstdaux nolonger provide static libs and should not be a private lib requirement for libscipash
2.add Libs.private for static linking in python module siphash24